### PR TITLE
Switch to standalone cobra-cli dependency

### DIFF
--- a/install_gotools.sh
+++ b/install_gotools.sh
@@ -44,7 +44,7 @@ GOPKGS=(
 	github.com/Masterminds/glide \
 	github.com/golang/dep/cmd/dep \
 	github.com/golang/protobuf/protoc-gen-go \
-	github.com/spf13/cobra/cobra \
+	github.com/spf13/cobra-cli \
 	github.com/ahmetb/govvv \
 
 	# misc


### PR DESCRIPTION
Switches to use the extracted cobra-cli command since it is being removed from the github.com/spf13/cobra module (xref https://github.com/spf13/cobra/issues/1597)